### PR TITLE
Switch to Object.entries

### DIFF
--- a/src/components/Menu/Menu.jsx
+++ b/src/components/Menu/Menu.jsx
@@ -4,7 +4,7 @@ import {v4 as uuidv4} from 'uuid';
 import { FaSun } from 'react-icons/fa'
 
 const Menu = ({ menu, title }) => {
-  const menuItems = Object.keys(menu)
+  const menuItems = Object.entries(menu)
   return (
     <div className="menuContainer">
       <FaSun className='spinningIcon' size="20" />
@@ -12,11 +12,11 @@ const Menu = ({ menu, title }) => {
       <h2>Items and prices are quantum.</h2>
       <div className="menuContentsGrid">
         {
-          menuItems.map(item => {
+          menuItems.map([item, price] => {
             return(
               <div className='menuContent' key={uuidv4()}>
                 <div className='itemName'>{item}</div>
-                <div className='itemPrice'>{menu[item]}</div>
+                <div className='itemPrice'>{price}</div>
               </div>
             )
           })


### PR DESCRIPTION
I feel like [Object.entries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries) deserves more love! It functions a lot like `dict.items()` in Python, and allows for naming the value variable more nicely. It also avoids possible side-effects of the value being modified in the middle of a function for `async` operations.